### PR TITLE
Fix NPE when player is teleported during login

### DIFF
--- a/src/simplepets/brainsynder/events/MainListeners.java
+++ b/src/simplepets/brainsynder/events/MainListeners.java
@@ -177,8 +177,8 @@ public class MainListeners implements Listener {
     public void onTeleport(final PlayerTeleportEvent e) {
         final Player p = e.getPlayer();
         final PetOwner owner = PetOwner.getPetOwner(p);
-        if (owner.hasPet()) {
-            try {
+        try{
+            if (owner.hasPet()) {
                 if (e.getCause() != PlayerTeleportEvent.TeleportCause.UNKNOWN) {
                     if (p.getPassenger() != null) {
                         e.setCancelled(true);
@@ -203,8 +203,8 @@ public class MainListeners implements Listener {
                         }.runTaskLater(PetCore.get(), 40);
                     }
                 }
-            } catch (Exception ignored) {
             }
+        } catch (Exception ignored) {
         }
     }
 


### PR DESCRIPTION
Put the try/catch in a place to catch an NPE when the PetOwner is null as they're not yet logged in when teleported. Usually occurs with a teleport-to-spawn-on-login plugin.

Example: https://pastebin.com/w7hymkA0