### PR TITLE
Only reload config files when they change

### DIFF
--- a/MAIN/src/main/java/simplepets/brainsynder/storage/files/base/FileMaker.java
+++ b/MAIN/src/main/java/simplepets/brainsynder/storage/files/base/FileMaker.java
@@ -7,6 +7,7 @@ import org.bukkit.inventory.ItemStack;
 import org.bukkit.plugin.Plugin;
 import simple.brainsynder.storage.IStorage;
 import simple.brainsynder.storage.StorageList;
+import simplepets.brainsynder.PetCore;
 
 import java.io.File;
 import java.io.IOException;
@@ -15,6 +16,7 @@ import java.util.*;
 public class FileMaker {
     private File file;
     private FileConfiguration configuration;
+    private long lastModified;
 
     public FileMaker(Plugin plugin, String directory, String fileName) {
         try {
@@ -26,6 +28,7 @@ public class FileMaker {
 
             new File(plugin.getDataFolder().toString() + File.separator + directory, fileName);
             this.configuration = YamlConfiguration.loadConfiguration(file);
+            this.lastModified = file.lastModified();
         } catch (Throwable ignored) {
         }
     }
@@ -39,6 +42,7 @@ public class FileMaker {
 
             this.file = new File(folder, fileName);
             this.configuration = YamlConfiguration.loadConfiguration(file);
+            this.lastModified = file.lastModified();
         } catch (Throwable ignored) {
         }
     }
@@ -51,6 +55,14 @@ public class FileMaker {
         } catch (IOException ignored) {
         }
         this.configuration = YamlConfiguration.loadConfiguration(file);
+        this.lastModified = file.lastModified();
+    }
+
+    private void configReloadCheck() {
+        if(lastModified != file.lastModified()) {
+            this.configuration = YamlConfiguration.loadConfiguration(file);
+            lastModified = file.lastModified();
+        }
     }
 
     public void setDefault (String key, Object value) {
@@ -58,7 +70,7 @@ public class FileMaker {
     }
 
     public String getString(String tag, boolean color) {
-        this.configuration = YamlConfiguration.loadConfiguration(file);
+        configReloadCheck();
         String value = configuration.getString(tag);
         if (value == null) return "";
         if (value.equals(tag)) return tag;
@@ -70,37 +82,37 @@ public class FileMaker {
     }
 
     public String getString(String tag) {
-        this.configuration = YamlConfiguration.loadConfiguration(file);
+        configReloadCheck();
         return this.configuration.get(tag) != null ? this.configuration.getString(tag) : tag;
     }
 
     public ItemStack getItemStack(String tag) {
-        this.configuration = YamlConfiguration.loadConfiguration(file);
+        configReloadCheck();
         return this.configuration.getItemStack(tag);
     }
 
     public boolean getBoolean(String tag) {
-        this.configuration = YamlConfiguration.loadConfiguration(file);
+        configReloadCheck();
         return this.configuration.get(tag) != null && this.configuration.getBoolean(tag);
     }
 
     public int getInt(String tag) {
-        this.configuration = YamlConfiguration.loadConfiguration(file);
+        configReloadCheck();
         return this.configuration.get(tag) != null ? this.configuration.getInt(tag) : 0;
     }
 
     public double getDouble(String tag) {
-        this.configuration = YamlConfiguration.loadConfiguration(file);
+        configReloadCheck();
         return this.configuration.get(tag) != null ? this.configuration.getDouble(tag) : 0.0D;
     }
 
     public Set<String> getKeys(boolean tag) {
-        this.configuration = YamlConfiguration.loadConfiguration(file);
+        configReloadCheck();
         return this.configuration.getKeys(tag);
     }
 
     public List<String> getStringList(String tag) {
-        this.configuration = YamlConfiguration.loadConfiguration(file);
+        configReloadCheck();
         return (List) (this.isSet(tag) ? this.configuration.getStringList(tag) : new ArrayList());
     }
 
@@ -109,17 +121,17 @@ public class FileMaker {
     }
 
     public boolean isSet(String tag) {
-        this.configuration = YamlConfiguration.loadConfiguration(file);
+        configReloadCheck();
         return this.configuration.get(tag) != null;
     }
 
     public ConfigurationSection getSection(String tag) {
-        this.configuration = YamlConfiguration.loadConfiguration(file);
+        configReloadCheck();
         return this.configuration.getConfigurationSection(tag);
     }
 
     public Object get(String tag) {
-        this.configuration = YamlConfiguration.loadConfiguration(file);
+        configReloadCheck();
         return this.configuration.get(tag);
     }
 
@@ -150,7 +162,7 @@ public class FileMaker {
     }
 
     public Map<String, Object> getConfigSectionValue(Object o, boolean deep) {
-        this.configuration = YamlConfiguration.loadConfiguration(file);
+        configReloadCheck();
         Map<String, Object> map = new HashMap();
         if (o == null) {
             return map;


### PR DESCRIPTION
Right now, getting values from the config causes a full reload of the config everytime. This can be very taxing when calling it a lot, for example whenever the pet moves it checks the config, which causes the config to reload every tick.

This is not foolproof, but should be good enough for this purpose, and is much much much faster!