### PR TITLE
Fix database issues and saved pets issues

### DIFF
--- a/MAIN/src/main/java/simplepets/brainsynder/PetCore.java
+++ b/MAIN/src/main/java/simplepets/brainsynder/PetCore.java
@@ -127,7 +127,11 @@ public class PetCore extends JavaPlugin implements IPetsPlugin {
     @Override
     public void onDisable() {
         SimplePets.getDebugLogger().debug(DebugLevel.NORMAL, "Saving player pets (if there are any)", false);
-        USER_MANAGER.getAllUsers().forEach(user -> ((PetOwner) user).markForRespawn());
+        USER_MANAGER.getAllUsers().forEach(user -> {
+            if (user.getPlayer() != null) {
+                ((PetOwner) user).markForRespawn();
+            }
+        });
 
         DebugCommand.fetchDebug(json -> {
             json.set("reloaded", !isShuttingDown());

--- a/MAIN/src/main/java/simplepets/brainsynder/impl/PetOwner.java
+++ b/MAIN/src/main/java/simplepets/brainsynder/impl/PetOwner.java
@@ -60,8 +60,6 @@ public class PetOwner implements PetUser {
         petMap = new HashMap<>();
         nameMap = new HashMap<>();
         ownedPets = new ArrayList<>();
-
-        loadCompound(PlayerSQL.getInstance().getCache(uuid));
     }
 
     public PetOwner(String username) {

--- a/MAIN/src/main/java/simplepets/brainsynder/listeners/AddonGUIListener.java
+++ b/MAIN/src/main/java/simplepets/brainsynder/listeners/AddonGUIListener.java
@@ -101,7 +101,6 @@ public class AddonGUIListener implements Listener {
         if (e.getInventory().getHolder() == null) return;
         if (!(e.getInventory().getHolder() instanceof AddonHolder)) return;
         AddonMenu menu = InventoryManager.ADDONS;
-        if (e.getPlayer().getOpenInventory() == null)
-            SimplePets.getUserManager().getPetUser((Player) e.getPlayer()).ifPresent(menu::reset);
+        SimplePets.getUserManager().getPetUser((Player) e.getPlayer()).ifPresent(menu::reset);
     }
 }

--- a/MAIN/src/main/java/simplepets/brainsynder/listeners/JoinLeaveListeners.java
+++ b/MAIN/src/main/java/simplepets/brainsynder/listeners/JoinLeaveListeners.java
@@ -29,14 +29,9 @@ public class JoinLeaveListeners implements Listener {
             @Override
             public void run() {
                 PlayerSQL.getInstance().fetchData(event.getPlayer().getUniqueId()).thenAccept(data -> {
-                    // Check if the user is cached.
-                    boolean load = SimplePets.getUserManager().isUserCached(event.getPlayer());
-                    // Assuming the player is not just a mindless NPC, this will always run.
-                    // However, if the user is not cached (in which case we don't want to load anything)...
-                    // It will initiate the PetOwner object which will load a new StorageCompound already.
-                    // If it is cached though, load the data from the DB.
+                    // Always reload the data in case we're part of a multi-
+                    // server network and the data was changed on another server
                     SimplePets.getUserManager().getPetUser(event.getPlayer()).ifPresent(user -> {
-                        if (!load) return;
                         ((PetOwner) user).loadCompound(data);
                     });
                 });

--- a/MAIN/src/main/java/simplepets/brainsynder/listeners/PetSelectorGUIListener.java
+++ b/MAIN/src/main/java/simplepets/brainsynder/listeners/PetSelectorGUIListener.java
@@ -56,7 +56,6 @@ public class PetSelectorGUIListener implements Listener {
         if (e.getInventory().getHolder() == null) return;
         if (!(e.getInventory().getHolder() instanceof SelectorHolder)) return;
         PetSelectorMenu menu = InventoryManager.SELECTOR;
-        if (e.getPlayer().getOpenInventory() == null)
-            SimplePets.getUserManager().getPetUser((Player) e.getPlayer()).ifPresent(menu::reset);
+        SimplePets.getUserManager().getPetUser((Player) e.getPlayer()).ifPresent(menu::reset);
     }
 }

--- a/MAIN/src/main/java/simplepets/brainsynder/listeners/SavesGUIListener.java
+++ b/MAIN/src/main/java/simplepets/brainsynder/listeners/SavesGUIListener.java
@@ -71,7 +71,6 @@ public class SavesGUIListener implements Listener {
         if (e.getInventory().getHolder() == null) return;
         if (!(e.getInventory().getHolder() instanceof SavesHolder)) return;
         SavesMenu menu = InventoryManager.PET_SAVES;
-        if (e.getPlayer().getOpenInventory() == null)
-            SimplePets.getUserManager().getPetUser((Player) e.getPlayer()).ifPresent(menu::reset);
+        SimplePets.getUserManager().getPetUser((Player) e.getPlayer()).ifPresent(menu::reset);
     }
 }

--- a/MAIN/src/main/java/simplepets/brainsynder/listeners/SelectionGUIListener.java
+++ b/MAIN/src/main/java/simplepets/brainsynder/listeners/SelectionGUIListener.java
@@ -86,7 +86,6 @@ public class SelectionGUIListener implements Listener {
         if (e.getInventory().getHolder() == null) return;
         if (!(e.getInventory().getHolder() instanceof SelectionHolder)) return;
         SelectionMenu menu = InventoryManager.SELECTION;
-        if (e.getPlayer().getOpenInventory() == null)
-            SimplePets.getUserManager().getPetUser((Player) e.getPlayer()).ifPresent(menu::reset);
+        SimplePets.getUserManager().getPetUser((Player) e.getPlayer()).ifPresent(menu::reset);
     }
 }

--- a/MAIN/src/main/java/simplepets/brainsynder/menu/inventory/SavesMenu.java
+++ b/MAIN/src/main/java/simplepets/brainsynder/menu/inventory/SavesMenu.java
@@ -120,12 +120,7 @@ public class SavesMenu extends CustomInventory {
 
 
         ListPager<PetUser.Entry<PetType, StorageTagCompound>> pages = new ListPager<>(maxPets, new ArrayList<>(savedPets));
-
-        if (pagerMap.containsKey(player.getName())) {
-            pages = pagerMap.get(player.getName());
-        } else {
-            pagerMap.put(player.getName(), pages);
-        }
+        pagerMap.put(player.getName(), pages);
 
         getSlots().forEach((slot, item) -> {
             if (item.isEnabled() && item.addItemToInv(user, this))

--- a/MAIN/src/main/java/simplepets/brainsynder/sql/PlayerSQL.java
+++ b/MAIN/src/main/java/simplepets/brainsynder/sql/PlayerSQL.java
@@ -33,7 +33,6 @@ import java.util.function.Consumer;
 
 public class PlayerSQL extends SQLManager {
     private static PlayerSQL instance;
-    private final Map<UUID, StorageTagCompound> dataCache = Maps.newHashMap();
 
     public PlayerSQL() {
         super(false);
@@ -89,39 +88,7 @@ public class PlayerSQL extends SQLManager {
                 exception.printStackTrace();
             }
             transferOldData();
-
-            Map<UUID, StorageTagCompound> cache = new HashMap<>();
-            try (Connection connection = implementConnection()) {
-                PreparedStatement statement = connection.prepareStatement("SELECT * FROM `" + tablePrefix + "_players`");
-                ResultSet results = statement.executeQuery();
-                while (results.next()) {
-                    String uuid = results.getString("uuid");
-                    try {
-                        StorageTagCompound compound = rowToCompound(UUID.fromString(uuid), results, true);
-                        cache.put(UUID.fromString(uuid), compound);
-                        // Cache the data...
-                    } catch (NullPointerException | IllegalArgumentException ex) {
-                        // Failed...
-                    }
-                }
-                results.close();
-                statement.close();
-
-                new BukkitRunnable() {
-                    @Override
-                    public void run() {
-                        dataCache.putAll(cache);
-                    }
-                }.runTask(PetCore.getInstance());
-
-            } catch (SQLException throwables) {
-                throwables.printStackTrace();
-            }
         });
-    }
-
-    public StorageTagCompound getCache(UUID uuid) {
-        return dataCache.getOrDefault(uuid, new StorageTagCompound());
     }
 
     @Override


### PR DESCRIPTION
The first commit fixes an issue where clicking on the save pet button won't make it appear in the saved pets GUI. I'm not sure why there's a check in the inventory-close listeners that only resets the GUI if the player has `null` open inventory. The `getOpenInventory` method never returns `null`, so the GUI never gets reset/refreshed.

EDIT: I thought I might as well update the close-listeners unrelated to the saved pets GUI.

The second commit fixes an issue where stopping the server wipes all data in the database of players who joined since the server was last started. The problem is that pet user data gets cleared when a player leaves the server and that pet users are kept cached as long as the server is running.

The third commit fixes an issue where saved pets are wiped when a player joins for the first time after a server restart. The problem was that saved pets are not loaded into the data compound when the data cache is initialised when the plugin enables.

The fourth commit fixes an issue where deleting a saved pet by right clicking it, doesn't remove it immediately from the GUI. The GUI didn't get refreshed.

This pull request makes saved pets work fully for me, and it also makes other database-related things like spawned pets work fully for me (e.g. they spawn properly after server restarts).

However, there is still an issue remaining in multi-server setups with BungeeCord. The problem is the following:
1. Start server A with SimplePets and MySQL set up.
2. Start server B with SimplePets and MySQL set up (same database).
3. Join server A, spawn a new pet and save a pet.
4. Join server B. The pet spawned in server A won't show up and the saved pet won't show up.

The problem is that SimplePets does an initial fetch of the entire database when the server starts up, and caches that data. When a player joins for the first time after a restart, it doesn't refetch the data from the database (i.e. it doesn't apply the changes made in step 3. when you join server B). It uses the data that was present in the database when server B started up instead.

I'm not entirely sure what the initial database fetch + cache is for (in `PlayerSQL`). If I remove those two things and refetch data from the database whenever a player joins (regardless of whether they have a pet user object or not, see `JoinLeaveListeners`),  it fixes that multi-server issue.

I can push the commit that fixes the multi-server issue to this PR, but I'm not sure if it is something you want since it gets rid of the initial database fetch.