### PR TITLE
[WIP] Address in-game conflicts (should close #123)

### DIFF
--- a/API/src/main/java/simplepets/brainsynder/addon/presets/EconomyAddon.java
+++ b/API/src/main/java/simplepets/brainsynder/addon/presets/EconomyAddon.java
@@ -161,7 +161,7 @@ public abstract class EconomyAddon extends PetAddon {
         String price = String.valueOf(priceMap.getOrDefault(type, 2000.0));
         if (price.equals("-1")) price = freePrice;
 
-        if (hidePrice && (AddonPermissions.hasPermission(this, (Player) event.getUser().getPlayer(), typePermissions.get(type)))) price = bypassPrice;
+        if (hidePrice && (AddonPermissions.hasPermission(this, event.getUser().getPlayer(), typePermissions.get(type)))) price = bypassPrice;
         boolean contains = petArray.contains(type);
         for (String line : lore)
             maker.addLore(line.replace("{price}", price).replace("{purchased}", String.valueOf(var(contains))));
@@ -172,7 +172,7 @@ public abstract class EconomyAddon extends PetAddon {
     @EventHandler(priority = EventPriority.HIGHEST)
     public void onSelect(PetSelectTypeEvent event) {
         if (!isEnabled()) return;
-        if (AddonPermissions.hasPermission(this, (Player) event.getUser().getPlayer(), typePermissions.get(event.getPetType()))) return;
+        if (AddonPermissions.hasPermission(this, event.getUser().getPlayer(), typePermissions.get(event.getPetType()))) return;
 
         double price = priceMap.getOrDefault(event.getPetType(), 2000.0);
         if (price == -1) return; // The pet is free, return
@@ -186,7 +186,7 @@ public abstract class EconomyAddon extends PetAddon {
         // Checks the players balance (if they have a balance that is lower then the price)
         if (bal < price) {
             event.setCancelled(true);
-            ((Player) user.getPlayer()).sendMessage(Colorize.translateBungeeHex(insufficientFunds
+            user.getPlayer().sendMessage(Colorize.translateBungeeHex(insufficientFunds
                     .replace("{price}", String.valueOf(price))
                     .replace("{type}", event.getPetType().getName())
                     .replace("{prefix}", prefix)
@@ -197,7 +197,7 @@ public abstract class EconomyAddon extends PetAddon {
         // Checks if PayPerUse is enabled, if it is dont add the pet to the players purchased list
         if (payPerUse) {
             withdraw(user.getPlayer().getUniqueId(), price);
-            ((Player) user.getPlayer()).sendMessage(Colorize.translateBungeeHex(paid
+            user.getPlayer().sendMessage(Colorize.translateBungeeHex(paid
                     .replace("{price}", String.valueOf(price))
                     .replace("{type}", event.getPetType().getName())
                     .replace("{prefix}", prefix)
@@ -208,7 +208,7 @@ public abstract class EconomyAddon extends PetAddon {
         // withdraw money, and add pet to the players purchased list
         user.addOwnedPet(event.getPetType());
         withdraw(user.getPlayer().getUniqueId(), price);
-        ((Player) user.getPlayer()).sendMessage(Colorize.translateBungeeHex(successfulPayment
+        user.getPlayer().sendMessage(Colorize.translateBungeeHex(successfulPayment
                 .replace("{price}", String.valueOf(price))
                 .replace("{type}", event.getPetType().getName())
                 .replace("{prefix}", prefix)

--- a/API/src/main/java/simplepets/brainsynder/api/entity/IEntityPet.java
+++ b/API/src/main/java/simplepets/brainsynder/api/entity/IEntityPet.java
@@ -7,10 +7,7 @@ import simplepets.brainsynder.api.entity.misc.IEntityBase;
 import simplepets.brainsynder.api.pet.PetType;
 import simplepets.brainsynder.api.user.PetUser;
 
-import java.util.Arrays;
-import java.util.List;
-import java.util.Optional;
-import java.util.UUID;
+import java.util.*;
 import java.util.function.Function;
 
 public interface IEntityPet extends IEntityBase, IBurnablePet {
@@ -48,7 +45,7 @@ public interface IEntityPet extends IEntityBase, IBurnablePet {
      * Will return all the entities involved in the pet
      */
     default List<Entity> getEntities() {
-        return Arrays.asList(getEntity());
+        return Collections.singletonList(getEntity());
     }
 
     /**

--- a/API/src/main/java/simplepets/brainsynder/api/pet/PetType.java
+++ b/API/src/main/java/simplepets/brainsynder/api/pet/PetType.java
@@ -353,14 +353,17 @@ public enum PetType {
         this(entityClass, new ItemBuilder(Material.PLAYER_HEAD).setTexture("http://textures.minecraft.net/texture/" + textureID));
     }
 
+    @SafeVarargs
     PetType(Class<? extends IEntityPet> entityClass, Material material, Class<? extends PetData>... petData) {
         this(entityClass, new ItemBuilder(material), petData);
     }
 
+    @SafeVarargs
     PetType(Class<? extends IEntityPet> entityClass, String textureID, Class<? extends PetData>... petData) {
         this(entityClass, new ItemBuilder(Material.PLAYER_HEAD).setTexture("http://textures.minecraft.net/texture/" + textureID), petData);
     }
 
+    @SafeVarargs
     PetType(Class<? extends IEntityPet> entityClass, ItemBuilder builder, Class<? extends PetData>... petData) {
         this.entityClass = entityClass;
         LinkedList<Class<? extends PetData>> list = Lists.newLinkedList();

--- a/MAIN/src/main/java/simplepets/brainsynder/files/Config.java
+++ b/MAIN/src/main/java/simplepets/brainsynder/files/Config.java
@@ -134,7 +134,7 @@ public class Config extends YamlFile {
         addDefault(LIMIT_CHARS_TOGGLE, false, "Should the name have a limited number of characters?\nDefault: false");
         addDefault(LIMIT_CHARS_TOGGLE, false, "Should the name have a limited number of characters?\nDefault: false");
         addDefault(LIMIT_CHARS_NUMBER, 10, "What should the character limit be set to?\nDefault: 10");
-        addDefault("RenamePet.Blocked-Words", Arrays.asList("jeb_"),
+        addDefault("RenamePet.Blocked-Words", Collections.singletonList("jeb_"),
                 "Are there words you don't want in a pets name?\n" +
                         "   If you put word in between [] it will check if it contains ANY part of the word\n" +
                         "         Example: [ass] will also flag glass because it contains the word in it\n" +

--- a/MAIN/src/main/java/simplepets/brainsynder/hooks/ProtocolHook.java
+++ b/MAIN/src/main/java/simplepets/brainsynder/hooks/ProtocolHook.java
@@ -57,7 +57,7 @@ public class ProtocolHook {
                         }
                     }.runTask(PetCore.getInstance());
                     return true;
-                }).open((Player) user.getPlayer());
+                }).open(user.getPlayer());
     }
 
     static {

--- a/MAIN/src/main/java/simplepets/brainsynder/listeners/AddonGUIListener.java
+++ b/MAIN/src/main/java/simplepets/brainsynder/listeners/AddonGUIListener.java
@@ -19,7 +19,6 @@ import simplepets.brainsynder.api.plugin.SimplePets;
 import simplepets.brainsynder.managers.InventoryManager;
 import simplepets.brainsynder.menu.inventory.AddonMenu;
 import simplepets.brainsynder.menu.inventory.holders.AddonHolder;
-import simplepets.brainsynder.menu.inventory.holders.SelectionHolder;
 import simplepets.brainsynder.utils.Keys;
 
 import java.util.Optional;

--- a/MAIN/src/main/java/simplepets/brainsynder/listeners/AddonGUIListener.java
+++ b/MAIN/src/main/java/simplepets/brainsynder/listeners/AddonGUIListener.java
@@ -1,5 +1,6 @@
 package simplepets.brainsynder.listeners;
 
+import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
 import org.bukkit.entity.Player;
 import org.bukkit.event.Event;
@@ -18,6 +19,7 @@ import simplepets.brainsynder.api.plugin.SimplePets;
 import simplepets.brainsynder.managers.InventoryManager;
 import simplepets.brainsynder.menu.inventory.AddonMenu;
 import simplepets.brainsynder.menu.inventory.holders.AddonHolder;
+import simplepets.brainsynder.menu.inventory.holders.SelectionHolder;
 import simplepets.brainsynder.utils.Keys;
 
 import java.util.Optional;
@@ -101,6 +103,10 @@ public class AddonGUIListener implements Listener {
         if (e.getInventory().getHolder() == null) return;
         if (!(e.getInventory().getHolder() instanceof AddonHolder)) return;
         AddonMenu menu = InventoryManager.ADDONS;
-        SimplePets.getUserManager().getPetUser((Player) e.getPlayer()).ifPresent(menu::reset);
+        Bukkit.getScheduler().runTaskLater(PetCore.getInstance(), () -> {
+            if (!(e.getPlayer().getOpenInventory().getTopInventory().getHolder() instanceof AddonHolder)) {
+                SimplePets.getUserManager().getPetUser((Player) e.getPlayer()).ifPresent(menu::reset);
+            }
+        }, 3);
     }
 }

--- a/MAIN/src/main/java/simplepets/brainsynder/listeners/PetEventListener.java
+++ b/MAIN/src/main/java/simplepets/brainsynder/listeners/PetEventListener.java
@@ -16,7 +16,7 @@ public class PetEventListener implements Listener {
         Config config = PetCore.getInstance().getConfiguration();
         String name = event.getName();
 
-        Player player = (Player) event.getUser().getPlayer();
+        Player player = event.getUser().getPlayer();
 
         if (config.getBoolean(Config.RENAME_TRIM, false)) name = name.trim();
         if (player.hasPermission("pet.name.bypass")) return;

--- a/MAIN/src/main/java/simplepets/brainsynder/listeners/PetSelectorGUIListener.java
+++ b/MAIN/src/main/java/simplepets/brainsynder/listeners/PetSelectorGUIListener.java
@@ -16,7 +16,6 @@ import simplepets.brainsynder.api.pet.PetType;
 import simplepets.brainsynder.api.plugin.SimplePets;
 import simplepets.brainsynder.managers.InventoryManager;
 import simplepets.brainsynder.menu.inventory.PetSelectorMenu;
-import simplepets.brainsynder.menu.inventory.holders.SelectionHolder;
 import simplepets.brainsynder.menu.inventory.holders.SelectorHolder;
 import simplepets.brainsynder.utils.Keys;
 

--- a/MAIN/src/main/java/simplepets/brainsynder/listeners/PetSelectorGUIListener.java
+++ b/MAIN/src/main/java/simplepets/brainsynder/listeners/PetSelectorGUIListener.java
@@ -1,5 +1,6 @@
 package simplepets.brainsynder.listeners;
 
+import org.bukkit.Bukkit;
 import org.bukkit.entity.Player;
 import org.bukkit.event.Event;
 import org.bukkit.event.EventHandler;
@@ -9,11 +10,13 @@ import org.bukkit.event.inventory.InventoryCloseEvent;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.meta.ItemMeta;
 import org.bukkit.persistence.PersistentDataType;
+import simplepets.brainsynder.PetCore;
 import simplepets.brainsynder.api.inventory.Item;
 import simplepets.brainsynder.api.pet.PetType;
 import simplepets.brainsynder.api.plugin.SimplePets;
 import simplepets.brainsynder.managers.InventoryManager;
 import simplepets.brainsynder.menu.inventory.PetSelectorMenu;
+import simplepets.brainsynder.menu.inventory.holders.SelectionHolder;
 import simplepets.brainsynder.menu.inventory.holders.SelectorHolder;
 import simplepets.brainsynder.utils.Keys;
 
@@ -56,6 +59,10 @@ public class PetSelectorGUIListener implements Listener {
         if (e.getInventory().getHolder() == null) return;
         if (!(e.getInventory().getHolder() instanceof SelectorHolder)) return;
         PetSelectorMenu menu = InventoryManager.SELECTOR;
-        SimplePets.getUserManager().getPetUser((Player) e.getPlayer()).ifPresent(menu::reset);
+        Bukkit.getScheduler().runTaskLater(PetCore.getInstance(), () -> {
+            if (!(e.getPlayer().getOpenInventory().getTopInventory().getHolder() instanceof SelectorHolder)) {
+                SimplePets.getUserManager().getPetUser((Player) e.getPlayer()).ifPresent(menu::reset);
+            }
+        }, 3);
     }
 }

--- a/MAIN/src/main/java/simplepets/brainsynder/listeners/SavesGUIListener.java
+++ b/MAIN/src/main/java/simplepets/brainsynder/listeners/SavesGUIListener.java
@@ -1,5 +1,6 @@
 package simplepets.brainsynder.listeners;
 
+import org.bukkit.Bukkit;
 import org.bukkit.entity.Player;
 import org.bukkit.event.Event;
 import org.bukkit.event.EventHandler;
@@ -14,6 +15,7 @@ import simplepets.brainsynder.api.user.PetUser;
 import simplepets.brainsynder.managers.InventoryManager;
 import simplepets.brainsynder.menu.inventory.SavesMenu;
 import simplepets.brainsynder.menu.inventory.holders.SavesHolder;
+import simplepets.brainsynder.menu.inventory.holders.SelectionHolder;
 import simplepets.brainsynder.utils.Utilities;
 
 import java.util.Optional;
@@ -71,6 +73,10 @@ public class SavesGUIListener implements Listener {
         if (e.getInventory().getHolder() == null) return;
         if (!(e.getInventory().getHolder() instanceof SavesHolder)) return;
         SavesMenu menu = InventoryManager.PET_SAVES;
-        SimplePets.getUserManager().getPetUser((Player) e.getPlayer()).ifPresent(menu::reset);
+        Bukkit.getScheduler().runTaskLater(PetCore.getInstance(), () -> {
+            if (!(e.getPlayer().getOpenInventory().getTopInventory().getHolder() instanceof SavesHolder)) {
+                SimplePets.getUserManager().getPetUser((Player) e.getPlayer()).ifPresent(menu::reset);
+            }
+        }, 3);
     }
 }

--- a/MAIN/src/main/java/simplepets/brainsynder/listeners/SavesGUIListener.java
+++ b/MAIN/src/main/java/simplepets/brainsynder/listeners/SavesGUIListener.java
@@ -15,7 +15,6 @@ import simplepets.brainsynder.api.user.PetUser;
 import simplepets.brainsynder.managers.InventoryManager;
 import simplepets.brainsynder.menu.inventory.SavesMenu;
 import simplepets.brainsynder.menu.inventory.holders.SavesHolder;
-import simplepets.brainsynder.menu.inventory.holders.SelectionHolder;
 import simplepets.brainsynder.utils.Utilities;
 
 import java.util.Optional;

--- a/MAIN/src/main/java/simplepets/brainsynder/listeners/SelectionGUIListener.java
+++ b/MAIN/src/main/java/simplepets/brainsynder/listeners/SelectionGUIListener.java
@@ -86,6 +86,10 @@ public class SelectionGUIListener implements Listener {
         if (e.getInventory().getHolder() == null) return;
         if (!(e.getInventory().getHolder() instanceof SelectionHolder)) return;
         SelectionMenu menu = InventoryManager.SELECTION;
-        SimplePets.getUserManager().getPetUser((Player) e.getPlayer()).ifPresent(menu::reset);
+        Bukkit.getScheduler().runTaskLater(PetCore.getInstance(), () -> {
+            if (!(e.getPlayer().getOpenInventory().getTopInventory().getHolder() instanceof SelectionHolder)) {
+                SimplePets.getUserManager().getPetUser((Player) e.getPlayer()).ifPresent(menu::reset);
+            }
+        }, 3);
     }
 }

--- a/MAIN/src/main/java/simplepets/brainsynder/managers/RenameManager.java
+++ b/MAIN/src/main/java/simplepets/brainsynder/managers/RenameManager.java
@@ -36,7 +36,7 @@ public class RenameManager {
             if (!renameEvent.isCancelled()) user.setPetName(renameEvent.getName(), type);
             return AnvilGUI.Response.close();
         }).title(MessageFile.getTranslation(MessageOption.RENAME_ANVIL_TITLE));
-        builder.open((Player) user.getPlayer());
+        builder.open(user.getPlayer());
     }
 
     public void renameViaChat (PetUser user, PetType type) {
@@ -47,7 +47,7 @@ public class RenameManager {
                     if (event.gracefulExit()) {
                         String name = event.getContext().getSessionData("name").toString(); // It's a string prompt for a reason
                         if (name.equalsIgnoreCase("cancel")) {
-                            ((Player)user.getPlayer()).sendMessage(MessageFile.getTranslation(MessageOption.RENAME_VIA_CHAT_CANCEL));
+                            user.getPlayer().sendMessage(MessageFile.getTranslation(MessageOption.RENAME_VIA_CHAT_CANCEL));
                             return;
                         }
                         if (name.equalsIgnoreCase("reset")) name = null;
@@ -58,7 +58,7 @@ public class RenameManager {
 
                     }
                 });
-        factory.buildConversation(((Player)user.getPlayer())).begin();
+        factory.buildConversation(user.getPlayer()).begin();
     }
 
     public void renameViaSign (PetUser user, PetType type) {

--- a/MAIN/src/main/java/simplepets/brainsynder/menu/inventory/AddonMenu.java
+++ b/MAIN/src/main/java/simplepets/brainsynder/menu/inventory/AddonMenu.java
@@ -69,7 +69,7 @@ public class AddonMenu extends CustomInventory {
         // Makes sure the slot numbers are sorted from low to high
         Set<Map.Entry<Integer, String>> set = object.entrySet();
         List<Map.Entry<Integer, String>> list = new ArrayList<>(set);
-        Collections.sort(list, Comparator.comparing(o -> (o.getKey())));
+        list.sort(Map.Entry.comparingByKey());
 
         JsonArray array = new JsonArray();
         for (Map.Entry<Integer, String> entry : list) {
@@ -92,7 +92,7 @@ public class AddonMenu extends CustomInventory {
     }
 
     public void open(PetUser user, int page, boolean installer) {
-        Player player = (Player) user.getPlayer();
+        Player player = user.getPlayer();
         installerMap.put(player.getName(), installer);
         pageSave.put(player.getName(), page);
         Inventory inv = Bukkit.createInventory(new AddonHolder(), getInteger("size", 54), Colorize.translateBungeeHex(getString("title", "&#de9790[] &#b35349SimplePets Addons")));

--- a/MAIN/src/main/java/simplepets/brainsynder/menu/inventory/DataMenu.java
+++ b/MAIN/src/main/java/simplepets/brainsynder/menu/inventory/DataMenu.java
@@ -43,7 +43,7 @@ public class DataMenu extends CustomInventory {
         // Makes sure the slot numbers are sorted from low to high
         Set<Map.Entry<Integer, String>> set = object.entrySet();
         List<Map.Entry<Integer, String>> list = new ArrayList<>(set);
-        Collections.sort(list, Comparator.comparing(o -> (o.getKey())));
+        list.sort(Map.Entry.comparingByKey());
 
         JsonArray array = new JsonArray();
         for (Map.Entry<Integer, String> entry : list) {
@@ -120,7 +120,6 @@ public class DataMenu extends CustomInventory {
             return;
         }
 
-        if (player.getOpenInventory() == null) return;
         Inventory inv = player.getOpenInventory().getTopInventory();
         if (inv.getHolder() == null) return;
         if (!(inv.getHolder() instanceof PetDataHolder)) return;

--- a/MAIN/src/main/java/simplepets/brainsynder/menu/inventory/PetSelectorMenu.java
+++ b/MAIN/src/main/java/simplepets/brainsynder/menu/inventory/PetSelectorMenu.java
@@ -60,7 +60,7 @@ public class PetSelectorMenu extends CustomInventory {
         // Makes sure the slot numbers are sorted from low to high
         Set<Map.Entry<Integer, String>> set = object.entrySet();
         List<Map.Entry<Integer, String>> list = new ArrayList<>(set);
-        Collections.sort(list, Comparator.comparing(o -> (o.getKey())));
+        list.sort(Map.Entry.comparingByKey());
 
         JsonArray array = new JsonArray();
         for (Map.Entry<Integer, String> entry : list) {
@@ -87,7 +87,7 @@ public class PetSelectorMenu extends CustomInventory {
     }
 
     public void open (PetUser user, int page, String title) {
-        Player player = (Player) user.getPlayer();
+        Player player = user.getPlayer();
         pageSave.put(player.getName(), page);
         Inventory inv = Bukkit.createInventory(new SelectorHolder(), getInteger("size", 54), Colorize.translateBungeeHex(title));
         int placeHolder = inv.getSize();

--- a/MAIN/src/main/java/simplepets/brainsynder/menu/inventory/SavesMenu.java
+++ b/MAIN/src/main/java/simplepets/brainsynder/menu/inventory/SavesMenu.java
@@ -60,7 +60,7 @@ public class SavesMenu extends CustomInventory {
 
         Set<Map.Entry<Integer, String>> set = object.entrySet();
         List<Map.Entry<Integer, String>> list = new ArrayList<>(set);
-        Collections.sort(list, Comparator.comparing(o -> (o.getKey())));
+        list.sort(Map.Entry.comparingByKey());
 
         JsonArray array = new JsonArray();
         for (Map.Entry<Integer, String> entry : list) {

--- a/MAIN/src/main/java/simplepets/brainsynder/menu/inventory/SelectionMenu.java
+++ b/MAIN/src/main/java/simplepets/brainsynder/menu/inventory/SelectionMenu.java
@@ -70,7 +70,7 @@ public class SelectionMenu extends CustomInventory {
         // Makes sure the slot numbers are sorted from low to high
         Set<Map.Entry<Integer, String>> set = object.entrySet();
         List<Map.Entry<Integer, String>> list = new ArrayList<>(set);
-        Collections.sort(list, Comparator.comparing(o -> (o.getKey())));
+        list.sort(Map.Entry.comparingByKey());
 
         JsonArray array = new JsonArray();
         for (Map.Entry<Integer, String> entry : list) {
@@ -115,7 +115,7 @@ public class SelectionMenu extends CustomInventory {
     @Override
     public void open(PetUser user, int page) {
         if (!isEnabled()) return;
-        Player player = (Player) user.getPlayer();
+        Player player = user.getPlayer();
         pageSave.put(player.getName(), page);
         Inventory inv = Bukkit.createInventory(new SelectionHolder(), getInteger("size", 54), Colorize.translateBungeeHex(getString("title", "&#de9790[] &#b35349Pets")));
         int placeHolder = inv.getSize();
@@ -175,7 +175,6 @@ public class SelectionMenu extends CustomInventory {
             } else {
                 SimplePets.getDebugLogger().debug(DebugLevel.WARNING, "Page does not exist (Page " + page + " / " + pages.totalPages() + ")");
             }
-
         }
         player.openInventory(inv);
     }

--- a/MAIN/src/main/java/simplepets/brainsynder/menu/items/list/Name.java
+++ b/MAIN/src/main/java/simplepets/brainsynder/menu/items/list/Name.java
@@ -35,11 +35,11 @@ public class Name extends Item {
         if (!masterUser.hasPets()) return;
         PetSelectorMenu menu = InventoryManager.SELECTOR;
         menu.setTask(masterUser.getPlayer().getName(), (user, type) -> {
-            ((Player)user.getPlayer()).closeInventory();
+            user.getPlayer().closeInventory();
             new BukkitRunnable() {
                 @Override
                 public void run() {
-                    ((Player)user.getPlayer()).performCommand("pet rename "+type.getName());
+                    user.getPlayer().performCommand("pet rename "+type.getName());
                 }
             }.runTaskLater(PetCore.getInstance(), 2);
         });

--- a/MAIN/src/main/java/simplepets/brainsynder/menu/items/list/PreviousPage.java
+++ b/MAIN/src/main/java/simplepets/brainsynder/menu/items/list/PreviousPage.java
@@ -27,12 +27,8 @@ public class PreviousPage extends Item {
 
     @Override
     public boolean addItemToInv(PetUser owner, CustomInventory inventory) {
-        if (inventory instanceof SelectionMenu) {
+        if (inventory instanceof SelectionMenu || inventory instanceof SavesMenu) {
             return inventory.getCurrentPage(owner) > 1;
-        }
-
-        if (inventory instanceof SavesMenu) {
-            return ((SavesMenu) inventory).getPages(owner).totalPages() > inventory.getCurrentPage(owner);
         }
 
         return false;

--- a/MAIN/src/main/java/simplepets/brainsynder/menu/items/list/Remove.java
+++ b/MAIN/src/main/java/simplepets/brainsynder/menu/items/list/Remove.java
@@ -40,7 +40,7 @@ public class Remove extends Item {
         if (!masterUser.hasPets()) return;
         PetSelectorMenu menu = InventoryManager.SELECTOR;
         menu.setTask(masterUser.getPlayer().getName(), (user, type) -> {
-            ((Player)user.getPlayer()).closeInventory();
+            user.getPlayer().closeInventory();
             new BukkitRunnable() {
                 @Override
                 public void run() {

--- a/MAIN/src/main/java/simplepets/brainsynder/sql/PlayerSQL.java
+++ b/MAIN/src/main/java/simplepets/brainsynder/sql/PlayerSQL.java
@@ -1,6 +1,5 @@
 package simplepets.brainsynder.sql;
 
-import com.google.common.collect.Maps;
 import lib.brainsynder.files.StorageFile;
 import lib.brainsynder.json.Json;
 import lib.brainsynder.json.JsonArray;
@@ -25,8 +24,6 @@ import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.util.Arrays;
-import java.util.HashMap;
-import java.util.Map;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.Consumer;

--- a/Version_1.17/src/main/java/simplepets/brainsynder/versions/v1_17_R1/entity/EntityPet.java
+++ b/Version_1.17/src/main/java/simplepets/brainsynder/versions/v1_17_R1/entity/EntityPet.java
@@ -4,7 +4,10 @@ import lib.brainsynder.nbt.StorageTagCompound;
 import lib.brainsynder.reflection.Reflection;
 import lib.brainsynder.sounds.SoundMaker;
 import lib.brainsynder.utils.Colorize;
+import net.minecraft.core.BlockPos;
 import net.minecraft.nbt.CompoundTag;
+import net.minecraft.network.protocol.Packet;
+import net.minecraft.network.protocol.game.ClientboundAddEntityPacket;
 import net.minecraft.network.protocol.game.ClientboundSetEntityDataPacket;
 import net.minecraft.network.syncher.SynchedEntityData;
 import net.minecraft.server.level.ServerPlayer;
@@ -55,6 +58,7 @@ import java.util.function.Function;
 public abstract class EntityPet extends Mob implements IEntityPet {
 
     private EntityType<? extends Mob> entityType;
+    private EntityType<? extends Mob> originalEntityType;
     private PetUser user;
     private PetType petType;
     private Map<String, StorageTagCompound> additional;
@@ -92,6 +96,7 @@ public abstract class EntityPet extends Mob implements IEntityPet {
     public EntityPet(EntityType<? extends Mob> entitytypes, Level world) {
         super(entitytypes, world);
         entityType = getEntityType(entitytypes);
+        originalEntityType = entitytypes;
         getBukkitEntity().remove();
     }
 
@@ -100,6 +105,7 @@ public abstract class EntityPet extends Mob implements IEntityPet {
         this.user = user;
         this.petType = type;
         entityType = getEntityType(entitytypes);
+        originalEntityType = entitytypes;
 
         this.additional = new HashMap<>();
 
@@ -524,6 +530,11 @@ public abstract class EntityPet extends Mob implements IEntityPet {
     @Override
     public EntityType<?> getType() {
         return entityType;
+    }
+
+    @Override
+    public Packet<?> getAddEntityPacket() {
+        return new ClientboundAddEntityPacket(this, originalEntityType, 0, new BlockPos(getX(), getY(), getZ()));
     }
 
     private void glowHandler(boolean glow) {

--- a/Version_1.17/src/main/java/simplepets/brainsynder/versions/v1_17_R1/entity/EntityPet.java
+++ b/Version_1.17/src/main/java/simplepets/brainsynder/versions/v1_17_R1/entity/EntityPet.java
@@ -97,9 +97,9 @@ public abstract class EntityPet extends Mob implements IEntityPet {
 
     public EntityPet(EntityType<? extends Mob> entitytypes, PetType type, PetUser user) {
         super(entitytypes, ((CraftWorld) user.getPlayer().getLocation().getWorld()).getHandle());
-        entityType = getEntityType(entitytypes);
         this.user = user;
         this.petType = type;
+        entityType = getEntityType(entitytypes);
 
         this.additional = new HashMap<>();
 
@@ -602,12 +602,13 @@ public abstract class EntityPet extends Mob implements IEntityPet {
         super.push(x, y, z);
     }
 
-    private static EntityType<? extends Mob> getEntityType(EntityType<? extends Mob> originalType)  {
+    private EntityType<? extends Mob> getEntityType(EntityType<? extends Mob> originalType)  {
         try {
             Field field = EntityType.class.getDeclaredField("bm");
             field.setAccessible(true);
             EntityType.Builder<? extends Mob> builder = EntityType.Builder.of((EntityType.EntityFactory<? extends Mob>) field.get(originalType), MobCategory.AMBIENT);
-            return builder.build("simplepets_pet");
+            builder.sized(0.1f, 0.1f);
+            return builder.build(petType.name().toLowerCase());
         } catch (IllegalAccessException | NoSuchFieldException e) {
             e.printStackTrace();
             return originalType;

--- a/Version_1.17/src/main/java/simplepets/brainsynder/versions/v1_17_R1/entity/list/EntityRabbitPet.java
+++ b/Version_1.17/src/main/java/simplepets/brainsynder/versions/v1_17_R1/entity/list/EntityRabbitPet.java
@@ -7,7 +7,6 @@ import net.minecraft.network.syncher.EntityDataSerializers;
 import net.minecraft.network.syncher.SynchedEntityData;
 import net.minecraft.util.Mth;
 import net.minecraft.world.entity.EntityType;
-import net.minecraft.world.entity.ai.attributes.Attributes;
 import net.minecraft.world.entity.ai.navigation.PathNavigation;
 import net.minecraft.world.level.pathfinder.Path;
 import net.minecraft.world.phys.Vec3;


### PR DESCRIPTION
Opened this as a pull request because this is gonna be one of those scary changes that can't be 100% fail-free, so I want to make sure any potential problems are addressed here rather than play Russian Roulette and cause problems on production servers.

Due to the way Minecraft works internally, it makes unexpected casts to SP's pets, which can cause said entities to vanish due to an exception thrown. However, before it makes any attempt at casting, it compares the entity types of the pet and the actual entity. Thus, this PR tries to use this to its advantage by changing the entity type used within the pets to force those checks to return false, and as a result, avoid said exceptions.

The change made is only minor, this being to the pet size to just throw off the game from the checks (making a custom entity type does not work lmao). However, with this in mind, there's still some potential problems to check for:

- How does this change behave with the addons?
- How does this change behave with plugins like WorldGuard and PlotSquared?
- How does it impact the current functionality of pets, especially considering the sizes are changed?