### PR TITLE
Add new tropical fish data to data permission

### DIFF
--- a/MAIN/src/main/resources/plugin.yml
+++ b/MAIN/src/main/resources/plugin.yml
@@ -1810,6 +1810,9 @@ permissions:
             pet.type.tropicalfish.data.frozen: true
             pet.type.tropicalfish.data.burning: true
             pet.type.tropicalfish.data.silent: true
+            pet.type.tropicalfish.data.body_color: true
+            pet.type.tropicalfish.data.pattern: true
+            pet.type.tropicalfish.data.pattern_color: true
 
 
     pet.type.turtle.data.*: # Grants access to all the data permissions for this pet


### PR DESCRIPTION
In https://github.com/brainsynder-Dev/SimplePets/pull/119 I forgot to add the data permissions for the new tropical fish data to `pet.type.tropicalfish.data.*`.