### PR TITLE
Adds more pet save customizations

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,4 +8,4 @@ updates:
       timezone: "Europe/Zurich"
     open-pull-requests-limit: 10
     labels:
-      - "dependabot"
+      - "Type: Dependabot"

--- a/.github/label-actions.yml
+++ b/.github/label-actions.yml
@@ -1,4 +1,4 @@
-fixed:
+"Status: Fixed":
   comment: |-
     :wave: @{issue-author},
 
@@ -18,12 +18,19 @@ fixed in v5:
   issues:
     close: true
 
-bug:
+"Type: Bug":
   comment: |-
-    :wave: @{issue-author},
+    @{issue-author},
 
     Thank you for reporting this bug, we will try and respond as soon as we can to your issue.
-    In the mean time have a look at the [WIKI](https://brainsynder.gitbook.io/simplepets/) to see if we made any mention to it on there.
+    In the meantime have a look at the [WIKI](https://brainsynder.gitbook.io/simplepets/) to see if we made any mention to it on there.
+
+"Status: Unsupported Version":
+  comment: |-
+    @{issue-author},
+
+    Your issue is based on an unsupported version of either Minecraft or SimplePets.
+    Please use up-to-date version and get back to us once you have tried it out on the latest versions.
 
 Added in Latest Build:
   comment: >
@@ -31,22 +38,35 @@ Added in Latest Build:
   issues:
     close: true
 
-blame-mojang:
+"Status: Blame Mojang":
   comment: >
     @{issue-author}, This is regarded as a Mojang issue we have no control over this.
   issues:
     close: true
 
-more info needed:
+"Status: Needs More Info":
   comment: |-
-    @{issue-author}, We need to collect a little more information reguarding this issue.
+    @{issue-author}, We need to collect a little more information regarding this issue.
     If this is a bug report: Please provide additional information to help us figure out what is happening
     If this is a feature request: Please provide more information on what you would like requested
 
-question answered:
+"Status: Unable to Reproduce":
+  comment: |-
+    @{issue-author},
+
+    Unfortunately we were unable to reproduce your issue.
+    Please provided more information regarding this issue such as:
+    - Your `/pet debug` link (Link generated after you run the command)
+    - Your `latest.log` (Or the log file that was around the time of the issue)
+    - Minecraft Version
+    - Spigot/Paper Version
+    - Video Evidence?
+    - Images?
+
+"Status: Answered":
   issues:
     close: true
 
-completed:
+"Status: Completed":
   issues:
     close: true

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -15,6 +15,6 @@ jobs:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           stale-issue-message: 'This issue has been marked as stale due to the lack of response on it. If this problem is still occurring, please comment saying so or the issue will be closed in 7 days.'
           stale-issue-label: 'stale'
-          exempt-issue-labels: 'addon idea,enhancement,feature request,successfully reproduced,dependabot,developer issue,todo'
+          exempt-issue-labels: 'Type: Addon Suggestion,Type: Enhancement,Type: Feature Request,Status: Reproduced,Type: Dependabot,Type: Developer Report,Type: Todo'
           days-before-stale: 30
           days-before-close: 7

--- a/.github/workflows/todo.yml
+++ b/.github/workflows/todo.yml
@@ -7,6 +7,6 @@ jobs:
       - uses: "actions/checkout@master"
       - name: "TODO to Issue"
         uses: "alstr/todo-to-issue-action@v3.0.2-beta"
-        id: "todo"
+        id: "Type: Todo"
         with:
           TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/API/src/main/java/simplepets/brainsynder/addon/presets/EconomyModule.java
+++ b/API/src/main/java/simplepets/brainsynder/addon/presets/EconomyModule.java
@@ -12,6 +12,7 @@ import simplepets.brainsynder.addon.PermissionData;
 import simplepets.brainsynder.addon.PetModule;
 import simplepets.brainsynder.api.event.inventory.PetInventoryAddPetItemEvent;
 import simplepets.brainsynder.api.event.inventory.PetSelectTypeEvent;
+import simplepets.brainsynder.api.inventory.handler.InventoryType;
 import simplepets.brainsynder.api.pet.PetType;
 import simplepets.brainsynder.api.user.PetUser;
 
@@ -156,6 +157,7 @@ public abstract class EconomyModule extends PetModule {
     @EventHandler
     public void onInventoryOpen(PetInventoryAddPetItemEvent event) {
         if (!isEnabled()) return;
+        if (event.getInventory().getInventoryType() != InventoryType.SUMMON_GUI) return;
         PetUser user = event.getUser();
         List<PetType> petArray = user.getOwnedPets();
 

--- a/API/src/main/java/simplepets/brainsynder/api/event/inventory/PetInventoryAddPetItemEvent.java
+++ b/API/src/main/java/simplepets/brainsynder/api/event/inventory/PetInventoryAddPetItemEvent.java
@@ -2,6 +2,7 @@ package simplepets.brainsynder.api.event.inventory;
 
 import org.bukkit.inventory.ItemStack;
 import simplepets.brainsynder.api.event.CancellablePetEvent;
+import simplepets.brainsynder.api.inventory.CustomInventory;
 import simplepets.brainsynder.api.pet.PetType;
 import simplepets.brainsynder.api.user.PetUser;
 
@@ -12,8 +13,10 @@ public class PetInventoryAddPetItemEvent extends CancellablePetEvent {
     private final PetUser user;
     private final PetType type;
     private ItemStack item;
+    private final CustomInventory inventory;
 
-    public PetInventoryAddPetItemEvent(PetUser user, PetType type, ItemStack item) {
+    public PetInventoryAddPetItemEvent(CustomInventory inventory, PetUser user, PetType type, ItemStack item) {
+        this.inventory = inventory;
         this.user = user;
         this.type = type;
         this.item = item;
@@ -33,5 +36,9 @@ public class PetInventoryAddPetItemEvent extends CancellablePetEvent {
 
     public void setItem(ItemStack item) {
         this.item = item;
+    }
+
+    public CustomInventory getInventory() {
+        return inventory;
     }
 }

--- a/API/src/main/java/simplepets/brainsynder/api/inventory/CustomInventory.java
+++ b/API/src/main/java/simplepets/brainsynder/api/inventory/CustomInventory.java
@@ -6,6 +6,7 @@ import lib.brainsynder.json.JsonObject;
 import org.bukkit.Bukkit;
 import org.bukkit.entity.Player;
 import org.bukkit.inventory.ItemStack;
+import simplepets.brainsynder.api.inventory.handler.InventoryType;
 import simplepets.brainsynder.api.plugin.SimplePets;
 import simplepets.brainsynder.api.user.PetUser;
 import simplepets.brainsynder.debug.DebugLevel;
@@ -121,6 +122,8 @@ public abstract class CustomInventory extends JsonFile {
 
         return slots;
     }
+
+    public abstract InventoryType getInventoryType ();
 
     /**
      * Size of the inventory

--- a/API/src/main/java/simplepets/brainsynder/api/inventory/handler/InventoryType.java
+++ b/API/src/main/java/simplepets/brainsynder/api/inventory/handler/InventoryType.java
@@ -1,0 +1,11 @@
+package simplepets.brainsynder.api.inventory.handler;
+
+public interface InventoryType {
+    InventoryType SUMMON_GUI = () -> "pet-summon";
+    InventoryType TYPE_SELECTION_GUI = () -> "pet-type-selection";
+    InventoryType SAVES_GUI = () -> "pet-saves";
+    InventoryType DATA_GUI = () -> "pet-data";
+    InventoryType ADDON_GUI = () -> "pet-addons";
+
+    String getRawType ();
+}

--- a/API/src/main/java/simplepets/brainsynder/api/plugin/config/ConfigOption.java
+++ b/API/src/main/java/simplepets/brainsynder/api/plugin/config/ConfigOption.java
@@ -404,6 +404,18 @@ public enum ConfigOption {
                     Bypass permission: `pet.saves.bypass`
                     
                     Default: {default}""");
+    public final ConfigEntry<List<String>> PET_SAVES_TYPE_LIMIT = createOption("pet-saves.pet-type-limits", Lists.newArrayList(""),
+            """
+                    This option allows you to list pet types and the limit for how many saves they can have
+                    
+                    Example: "COW-2"
+                    This example will make it so the COW pet type can only be saved 2 times
+                    
+                    Can be overrode via the permission `pet.saves.<type>.<amount>`
+                    Bypass permission: `pet.saves.bypass`
+                    Bypass permission: `pet.saves.<type>.bypass`
+                    
+                    Default: {default}""");
 
 
 

--- a/API/src/main/java/simplepets/brainsynder/api/plugin/config/ConfigOption.java
+++ b/API/src/main/java/simplepets/brainsynder/api/plugin/config/ConfigOption.java
@@ -387,6 +387,25 @@ public enum ConfigOption {
                     Default: {default}""").setPastPaths("PetToggles.Default-Ride-Speed");
 
 
+    public final ConfigEntry<Boolean> PET_SAVES_ENABLED = createOption("pet-saves.enabled", true,
+            """
+                    Do you want players to be able to save the pets they have spawned
+                    so they don't have to re-customize the pet to their state
+                    
+                    This option will essentially disable the Saves GUI/Item
+                    
+                    Default: {default}""");
+    public final ConfigEntry<Integer> PET_SAVES_LIMIT = createOption("pet-saves.default-limit", -1,
+            """
+                    How many pets do you want your players to be able to save?
+                    Set this to `-1` if you want no limit
+                    
+                    Can be overrode via the permission `pet.saves.<amount>`
+                    Bypass permission: `pet.saves.bypass`
+                    
+                    Default: {default}""");
+
+
 
     public final ConfigEntry<Boolean> RENAME_ENABLED = createOption("RenamePet.Enabled", true,
             """

--- a/API/src/main/java/simplepets/brainsynder/api/user/PetUser.java
+++ b/API/src/main/java/simplepets/brainsynder/api/user/PetUser.java
@@ -63,6 +63,13 @@ public interface PetUser {
         addPetSave(entity.asCompound());
     }
 
+    /**
+     * Whether the user is able to save more pets.
+     *
+     * If pet-saves is disabled, it will return false.
+     */
+    boolean canSaveMorePets ();
+
     boolean summonCachedPets ();
 
     /**
@@ -194,7 +201,7 @@ public interface PetUser {
     boolean hasPetVehicle();
 
     /**
-     * Whether or not the user should be able to spawn more pets.
+     * Whether the user should be able to spawn more pets.
      */
     boolean canSpawnMorePets();
 

--- a/MAIN/src/main/java/simplepets/brainsynder/files/MessageFile.java
+++ b/MAIN/src/main/java/simplepets/brainsynder/files/MessageFile.java
@@ -36,6 +36,9 @@ public class MessageFile {
                 addDefault(MessageOption.MODIFY_COMPOUND, "Message contains what the player has set the pets data to\nSet this as an empty string \"\" to prevent it from being sent");
                 addDefault(MessageOption.MODIFY_APPLIED, "Message that will be sent when the compound is applied to the entity");
 
+                addDefault(MessageOption.PET_SAVES_LIMIT_REACHED, "Message that will be sent when the player has reached their global limit for any pet type");
+                addDefault(MessageOption.PET_SAVES_LIMIT_REACHED_TYPE, "Message that will be sent when the player has reached their per-pet-type limit");
+
                 addDefault(MessageOption.PURCHASE_ADD, "Message that will be sent when a pet is added to the players purchased list (via '/pets purchased add')");
                 addDefault(MessageOption.PURCHASE_REMOVE, "Message that will be sent when a pet is removed from the players purchased list (via '/pets purchased remove')");
                 addDefault(MessageOption.PURCHASE_LIST_PREFIX, "Is what is sent before the pets are listed (via '/pets purchased list')");

--- a/MAIN/src/main/java/simplepets/brainsynder/files/options/MessageOption.java
+++ b/MAIN/src/main/java/simplepets/brainsynder/files/options/MessageOption.java
@@ -40,6 +40,9 @@ public enum MessageOption implements YamlOption {
     RENAME_ANVIL_TAG ("rename.anvil.tag_name", "&#de9790NEW NAME"),
     RENAME_SIGN_TEXT ("rename.sign.lines", Lists.newArrayList("{input}", "&l^^^^^^^^", "&9&lPlease Enter", "&9&lPet Name")),
 
+    PET_SAVES_LIMIT_REACHED ("pet-saves.limit-reached", "{prefix} &cYou have reached your limit for saving pet"),
+    PET_SAVES_LIMIT_REACHED_TYPE("pet-saves.limit-reached-per-type", "{prefix} &cYou have reached your limit for saving {type} pets"),
+
     PET_FILES_REGEN ("admin.regenerate.pets", "{prefix} &7The Pets folder has been regenerated to the default files."),
     INV_FILES_REGEN ("admin.regenerate.inventories", "{prefix} &7The Inventories folder has been regenerated to the default files."),
     ITEM_FILES_REGEN ("admin.regenerate.items", "{prefix} &7The Items folder has been regenerated to the default files."),

--- a/MAIN/src/main/java/simplepets/brainsynder/impl/PetOwner.java
+++ b/MAIN/src/main/java/simplepets/brainsynder/impl/PetOwner.java
@@ -331,6 +331,27 @@ public class PetOwner implements PetUser {
     }
 
     @Override
+    public boolean canSaveMorePets() {
+        if (!ConfigOption.INSTANCE.PET_SAVES_ENABLED.getValue()) return false;
+
+        int saveLimit = ConfigOption.INSTANCE.PET_SAVES_LIMIT.getValue();
+        if (saveLimit < 0) return true;
+
+        if (getPlayer().isOp()) return true;
+        if (getPlayer().hasPermission("pet.saves.bypass")) return true;
+
+        for (PermissionAttachmentInfo permission : getPlayer().getEffectivePermissions()) {
+            if (!permission.getValue()) continue;
+            if (!permission.getPermission().startsWith("pet.saves.")) continue;
+
+            String strAmount = permission.getPermission().substring(10);
+            int permAmount = Integer.parseInt(strAmount);
+            if (permAmount >= saveLimit) saveLimit = permAmount;
+        }
+        return savedPetData.size() < saveLimit;
+    }
+
+    @Override
     public List<PetType> getOwnedPets() {
         return ownedPets;
     }

--- a/MAIN/src/main/java/simplepets/brainsynder/impl/PetOwner.java
+++ b/MAIN/src/main/java/simplepets/brainsynder/impl/PetOwner.java
@@ -10,7 +10,6 @@ import org.bukkit.Bukkit;
 import org.bukkit.Material;
 import org.bukkit.entity.Entity;
 import org.bukkit.entity.Player;
-import org.bukkit.permissions.PermissionAttachmentInfo;
 import org.bukkit.scheduler.BukkitRunnable;
 import simplepets.brainsynder.PetCore;
 import simplepets.brainsynder.api.ISpawnUtil;
@@ -340,15 +339,7 @@ public class PetOwner implements PetUser {
         if (getPlayer().isOp()) return true;
         if (getPlayer().hasPermission("pet.saves.bypass")) return true;
 
-        for (PermissionAttachmentInfo permission : getPlayer().getEffectivePermissions()) {
-            if (!permission.getValue()) continue;
-            if (!permission.getPermission().startsWith("pet.saves.")) continue;
-
-            String strAmount = permission.getPermission().substring(10);
-            int permAmount = Integer.parseInt(strAmount);
-            if (permAmount >= saveLimit) saveLimit = permAmount;
-        }
-        return savedPetData.size() < saveLimit;
+        return savedPetData.size() < Utilities.getPermissionAmount(getPlayer(), saveLimit, "pet.saves.");
     }
 
     @Override
@@ -611,14 +602,7 @@ public class PetOwner implements PetUser {
         if (!getPlayer().isOnline()) return false;
         if (getPlayer().isOp()) return true;
         if (getPlayer().hasPermission("pet.amount.bypass")) return true;
-        for (PermissionAttachmentInfo permission : getPlayer().getEffectivePermissions()) {
-            if (!permission.getValue()) continue;
-            if (!permission.getPermission().startsWith("pet.amount.")) continue;
-            String strAmount = permission.getPermission().substring(11);
-            int permAmount = Integer.parseInt(strAmount);
-            if (permAmount >= maxAmount) maxAmount = permAmount;
-        }
-        return petMap.size() < maxAmount;
+        return petMap.size() < Utilities.getPermissionAmount(getPlayer(), maxAmount, "pet.amount.");
     }
 
     @Override

--- a/MAIN/src/main/java/simplepets/brainsynder/menu/inventory/AddonMenu.java
+++ b/MAIN/src/main/java/simplepets/brainsynder/menu/inventory/AddonMenu.java
@@ -21,6 +21,7 @@ import simplepets.brainsynder.addon.AddonCloudData;
 import simplepets.brainsynder.addon.PetModule;
 import simplepets.brainsynder.api.inventory.CustomInventory;
 import simplepets.brainsynder.api.inventory.Item;
+import simplepets.brainsynder.api.inventory.handler.InventoryType;
 import simplepets.brainsynder.api.plugin.SimplePets;
 import simplepets.brainsynder.api.user.PetUser;
 import simplepets.brainsynder.debug.DebugLevel;
@@ -85,6 +86,11 @@ public class AddonMenu extends CustomInventory {
     @Override
     public void onClick(int slot, ItemStack item, Player player) {
 
+    }
+
+    @Override
+    public InventoryType getInventoryType() {
+        return InventoryType.ADDON_GUI;
     }
 
     public boolean isInstallerGUI (PetUser user) {

--- a/MAIN/src/main/java/simplepets/brainsynder/menu/inventory/DataMenu.java
+++ b/MAIN/src/main/java/simplepets/brainsynder/menu/inventory/DataMenu.java
@@ -11,6 +11,7 @@ import org.bukkit.inventory.ItemStack;
 import simplepets.brainsynder.api.entity.IEntityPet;
 import simplepets.brainsynder.api.entity.misc.IEntityControllerPet;
 import simplepets.brainsynder.api.inventory.CustomInventory;
+import simplepets.brainsynder.api.inventory.handler.InventoryType;
 import simplepets.brainsynder.api.pet.PetType;
 import simplepets.brainsynder.api.plugin.config.ConfigOption;
 import simplepets.brainsynder.api.user.PetUser;
@@ -62,6 +63,11 @@ public class DataMenu extends CustomInventory {
     @Override
     public void onClick(int slot, ItemStack item, Player player) {
 
+    }
+
+    @Override
+    public InventoryType getInventoryType() {
+        return InventoryType.DATA_GUI;
     }
 
     public PetType getType(Player player) {

--- a/MAIN/src/main/java/simplepets/brainsynder/menu/inventory/PetSelectorMenu.java
+++ b/MAIN/src/main/java/simplepets/brainsynder/menu/inventory/PetSelectorMenu.java
@@ -17,6 +17,7 @@ import simplepets.brainsynder.api.entity.IEntityPet;
 import simplepets.brainsynder.api.event.inventory.PetTypeStorage;
 import simplepets.brainsynder.api.inventory.CustomInventory;
 import simplepets.brainsynder.api.inventory.Item;
+import simplepets.brainsynder.api.inventory.handler.InventoryType;
 import simplepets.brainsynder.api.pet.PetType;
 import simplepets.brainsynder.api.plugin.SimplePets;
 import simplepets.brainsynder.api.user.PetUser;
@@ -76,6 +77,11 @@ public class PetSelectorMenu extends CustomInventory {
     @Override
     public void onClick(int slot, ItemStack item, Player player) {
 
+    }
+
+    @Override
+    public InventoryType getInventoryType() {
+        return InventoryType.TYPE_SELECTION_GUI;
     }
 
     public void setTask (String name, BiTask<PetUser, PetType> task) {

--- a/MAIN/src/main/java/simplepets/brainsynder/menu/inventory/SavesMenu.java
+++ b/MAIN/src/main/java/simplepets/brainsynder/menu/inventory/SavesMenu.java
@@ -15,6 +15,7 @@ import simplepets.brainsynder.api.ISpawnUtil;
 import simplepets.brainsynder.api.event.inventory.PetInventoryAddPetItemEvent;
 import simplepets.brainsynder.api.inventory.CustomInventory;
 import simplepets.brainsynder.api.inventory.Item;
+import simplepets.brainsynder.api.inventory.handler.InventoryType;
 import simplepets.brainsynder.api.pet.PetType;
 import simplepets.brainsynder.api.plugin.SimplePets;
 import simplepets.brainsynder.api.plugin.config.ConfigOption;
@@ -77,6 +78,11 @@ public class SavesMenu extends CustomInventory {
     @Override
     public void onClick(int slot, ItemStack item, Player player) {
 
+    }
+
+    @Override
+    public InventoryType getInventoryType() {
+        return InventoryType.SAVES_GUI;
     }
 
     @Override
@@ -163,7 +169,7 @@ public class SavesMenu extends CustomInventory {
                         storageMap.put(compound, new PetUser.Entry<>(type, stack));
                     }
 
-                    PetInventoryAddPetItemEvent event = new PetInventoryAddPetItemEvent(user, entry.getKey(), stack);
+                    PetInventoryAddPetItemEvent event = new PetInventoryAddPetItemEvent(this, user, entry.getKey(), stack);
                     Bukkit.getPluginManager().callEvent(event);
 
 

--- a/MAIN/src/main/java/simplepets/brainsynder/menu/inventory/SelectionMenu.java
+++ b/MAIN/src/main/java/simplepets/brainsynder/menu/inventory/SelectionMenu.java
@@ -15,6 +15,7 @@ import simplepets.brainsynder.api.event.inventory.PetInventoryAddPetItemEvent;
 import simplepets.brainsynder.api.event.inventory.PetTypeStorage;
 import simplepets.brainsynder.api.inventory.CustomInventory;
 import simplepets.brainsynder.api.inventory.Item;
+import simplepets.brainsynder.api.inventory.handler.InventoryType;
 import simplepets.brainsynder.api.pet.IPetConfig;
 import simplepets.brainsynder.api.pet.PetType;
 import simplepets.brainsynder.api.plugin.SimplePets;
@@ -101,6 +102,11 @@ public class SelectionMenu extends CustomInventory {
 
     }
 
+    @Override
+    public InventoryType getInventoryType() {
+        return InventoryType.SUMMON_GUI;
+    }
+
     public void reloadAvailableTypes() {
         availableTypes.clear();
 
@@ -142,7 +148,7 @@ public class SelectionMenu extends CustomInventory {
         IStorage<PetTypeStorage> petTypes = new StorageList<>();
         for (PetType type : availableTypes) {
             PetTypeStorage storage = new PetTypeStorage(type);
-            PetInventoryAddPetItemEvent event = new PetInventoryAddPetItemEvent(user, storage.getType(), storage.getItem());
+            PetInventoryAddPetItemEvent event = new PetInventoryAddPetItemEvent(this, user, storage.getType(), storage.getItem());
 
             if (Utilities.hasPermission(player, type.getPermission())
                     || (user.getOwnedPets().contains(type) && ConfigOption.INSTANCE.UTILIZE_PURCHASED_PETS.getValue())) {
@@ -216,7 +222,7 @@ public class SelectionMenu extends CustomInventory {
         IStorage<PetTypeStorage> petTypes = new StorageList<>();
         for (PetType type : availableTypes) {
             PetTypeStorage storage = new PetTypeStorage(type);
-            PetInventoryAddPetItemEvent event = new PetInventoryAddPetItemEvent(user, storage.getType(), storage.getItem());
+            PetInventoryAddPetItemEvent event = new PetInventoryAddPetItemEvent(this, user, storage.getType(), storage.getItem());
 
             if (Utilities.hasPermission(player, type.getPermission())
                     || (user.getOwnedPets().contains(type) && ConfigOption.INSTANCE.UTILIZE_PURCHASED_PETS.getValue())) {

--- a/MAIN/src/main/java/simplepets/brainsynder/menu/items/list/SavePet.java
+++ b/MAIN/src/main/java/simplepets/brainsynder/menu/items/list/SavePet.java
@@ -88,11 +88,14 @@ public class SavePet extends Item {
         
         if (player.hasPermission("pet.saves."+entityPet.getPetType().getName()+".bypass")) return true;
 
+        int saveLimit = Utilities.parseTypeSaveLimit(entityPet.getPetType());
+        if (saveLimit < 0) return true;
+
         int typeCount = 0;
         for (PetUser.Entry<PetType, StorageTagCompound> entry : user.getSavedPets()) {
             if (entry.getKey() == entityPet.getPetType()) typeCount++;
         }
-        if (typeCount >= Utilities.getPermissionAmount(player, Utilities.parseTypeSaveLimit(entityPet.getPetType()), "pet.saves."+entityPet.getPetType().getName()+".")) {
+        if (typeCount >= Utilities.getPermissionAmount(player, saveLimit, "pet.saves."+entityPet.getPetType().getName()+".")) {
             player.sendMessage(MessageFile.getTranslation(MessageOption.PET_SAVES_LIMIT_REACHED_TYPE).replace("{type}", entityPet.getPetType().getName()));
             return false;
         }

--- a/MAIN/src/main/java/simplepets/brainsynder/menu/items/list/SavePet.java
+++ b/MAIN/src/main/java/simplepets/brainsynder/menu/items/list/SavePet.java
@@ -95,11 +95,11 @@ public class SavePet extends Item {
         for (PetUser.Entry<PetType, StorageTagCompound> entry : user.getSavedPets()) {
             if (entry.getKey() == entityPet.getPetType()) typeCount++;
         }
-        if (typeCount >= Utilities.getPermissionAmount(player, saveLimit, "pet.saves."+entityPet.getPetType().getName()+".")) {
-            player.sendMessage(MessageFile.getTranslation(MessageOption.PET_SAVES_LIMIT_REACHED_TYPE).replace("{type}", entityPet.getPetType().getName()));
-            return false;
-        }
 
-        return true;
+        if (typeCount < Utilities.getPermissionAmount(player, saveLimit, "pet.saves."+entityPet.getPetType().getName()+".")) {
+            return true;
+        }
+        player.sendMessage(MessageFile.getTranslation(MessageOption.PET_SAVES_LIMIT_REACHED_TYPE).replace("{type}", entityPet.getPetType().getName()));
+        return false;
     }
 }

--- a/MAIN/src/main/java/simplepets/brainsynder/menu/items/list/SavePet.java
+++ b/MAIN/src/main/java/simplepets/brainsynder/menu/items/list/SavePet.java
@@ -3,6 +3,7 @@ package simplepets.brainsynder.menu.items.list;
 import lib.brainsynder.item.ItemBuilder;
 import lib.brainsynder.nbt.StorageTagCompound;
 import org.bukkit.Material;
+import org.bukkit.entity.Player;
 import org.bukkit.scheduler.BukkitRunnable;
 import simplepets.brainsynder.PetCore;
 import simplepets.brainsynder.api.Namespace;
@@ -78,18 +79,21 @@ public class SavePet extends Item {
 
     private boolean canSavePet (PetUser user, IEntityPet entityPet) {
         if (!ConfigOption.INSTANCE.PET_SAVES_ENABLED.getValue()) return false;
+        Player player = user.getPlayer();
 
         if (!user.canSaveMorePets()) {
-            user.getPlayer().sendMessage(MessageFile.getTranslation(MessageOption.PET_SAVES_LIMIT_REACHED));
+            player.sendMessage(MessageFile.getTranslation(MessageOption.PET_SAVES_LIMIT_REACHED));
             return false;
         }
+        
+        if (player.hasPermission("pet.saves."+entityPet.getPetType().getName()+".bypass")) return true;
 
         int typeCount = 0;
         for (PetUser.Entry<PetType, StorageTagCompound> entry : user.getSavedPets()) {
             if (entry.getKey() == entityPet.getPetType()) typeCount++;
         }
-        if (typeCount >= Utilities.getPermissionAmount(user.getPlayer(), Utilities.parseTypeSaveLimit(entityPet.getPetType()), "pet.saves."+entityPet.getPetType().getName()+".")) {
-            user.getPlayer().sendMessage(MessageFile.getTranslation(MessageOption.PET_SAVES_LIMIT_REACHED_TYPE).replace("{type}", entityPet.getPetType().getName()));
+        if (typeCount >= Utilities.getPermissionAmount(player, Utilities.parseTypeSaveLimit(entityPet.getPetType()), "pet.saves."+entityPet.getPetType().getName()+".")) {
+            player.sendMessage(MessageFile.getTranslation(MessageOption.PET_SAVES_LIMIT_REACHED_TYPE).replace("{type}", entityPet.getPetType().getName()));
             return false;
         }
 

--- a/MAIN/src/main/java/simplepets/brainsynder/menu/items/list/SavePet.java
+++ b/MAIN/src/main/java/simplepets/brainsynder/menu/items/list/SavePet.java
@@ -29,6 +29,11 @@ public class SavePet extends Item {
     }
 
     @Override
+    public boolean addItemToInv(PetUser user, CustomInventory inventory) {
+        return user.canSaveMorePets();
+    }
+
+    @Override
     public void onClick(PetUser masterUser, CustomInventory inventory) {
         if (!masterUser.hasPets()) return;
         if (masterUser.getPetEntities().size() == 1) {

--- a/MAIN/src/main/java/simplepets/brainsynder/menu/items/list/Saves.java
+++ b/MAIN/src/main/java/simplepets/brainsynder/menu/items/list/Saves.java
@@ -5,6 +5,7 @@ import org.bukkit.Material;
 import simplepets.brainsynder.api.Namespace;
 import simplepets.brainsynder.api.inventory.CustomInventory;
 import simplepets.brainsynder.api.inventory.Item;
+import simplepets.brainsynder.api.plugin.config.ConfigOption;
 import simplepets.brainsynder.api.user.PetUser;
 import simplepets.brainsynder.managers.InventoryManager;
 
@@ -21,6 +22,11 @@ public class Saves extends Item {
         return new ItemBuilder(Material.COMMAND_BLOCK)
                 .withName("&#e3c79a&lPet Saves")
                 .addLore("&7", "&7View the pets you have saved");
+    }
+
+    @Override
+    public boolean addItemToInv(PetUser user, CustomInventory inventory) {
+        return ConfigOption.INSTANCE.PET_SAVES_ENABLED.getValue();
     }
 
     @Override

--- a/MAIN/src/main/java/simplepets/brainsynder/utils/Utilities.java
+++ b/MAIN/src/main/java/simplepets/brainsynder/utils/Utilities.java
@@ -199,6 +199,27 @@ public class Utilities {
         }
     }
 
+    public static int parseTypeSaveLimit (PetType type) {
+        for (String line : ConfigOption.INSTANCE.PET_SAVES_TYPE_LIMIT.getValue()) {
+            if (!line.contains("-")) continue;
+            String[] args = line.split("-");
+            if (args.length != 2) continue;
+
+            PetType target = PetType.getPetType(args[0]).orElse(null);
+            if (target == null) continue;
+
+            if (type != target) continue;
+            try {
+                return Integer.parseInt(args[1].trim());
+            }catch (NumberFormatException e) {
+                SimplePets.getDebugLogger().debug(DebugLevel.ERROR, "Unable to parse pet-type-limit for '"+args[0]+"', "+args[1]+" is not a valid number.");
+                return -1;
+            }
+        }
+
+        return -1;
+    }
+
     public static int getPermissionAmount (Player player, int defaultValue, String partialPermission) {
         int amount = defaultValue;
         if (!partialPermission.endsWith(".")) return defaultValue;

--- a/MAIN/src/main/java/simplepets/brainsynder/utils/Utilities.java
+++ b/MAIN/src/main/java/simplepets/brainsynder/utils/Utilities.java
@@ -199,6 +199,21 @@ public class Utilities {
         }
     }
 
+    public static int getPermissionAmount (Player player, int defaultValue, String partialPermission) {
+        int amount = defaultValue;
+        if (!partialPermission.endsWith(".")) return defaultValue;
+
+        for (PermissionAttachmentInfo permission : player.getEffectivePermissions()) {
+            if (!permission.getValue()) continue;
+            if (!permission.getPermission().startsWith(partialPermission)) continue;
+
+            String strAmount = permission.getPermission().substring( (partialPermission.lastIndexOf(".") + 1) );
+            int permAmount = Integer.parseInt(strAmount);
+            if (permAmount >= amount) amount = permAmount;
+        }
+        return amount;
+    }
+
     public static void removePassenger(Entity entity, Entity passenger) {
         try {
             entity.eject();


### PR DESCRIPTION
This PR aims to add more customization for pet saves like:

- Enable/Disable of pet saving
- A limit of how many pets can be saved
- A limit per-type of pet

Idea from: https://github.com/brainsynder-Dev/SimplePets/issues/96

### New permissions added:

- pet.saves.bypass - `bypasses all of the pet save limits`
- pet.saves.{amount} - `Overrides the default-limit value`
- pet.saves.{type}.bypass - `bypasses the selected pet types save limit`
- pet.saves.{type}.{amount} - `Overrides the selected pet types save limit (If it is set in the 'pet-type-limits' list)`
More info is available [HERE](https://wiki.bsdevelopment.org/permissions/other-permissions#miscellaneous-permissions)

### These are the new config options added in this PR:
```YAML
pet-saves:
  # Do you want players to be able to save the pets they have spawned
  # so they don't have to re-customize the pet to their state
  # 
  # This option will essentially disable the Saves GUI/Item
  # 
  # Default: true
  enabled: true
  # How many pets do you want your players to be able to save?
  # Set this to `-1` if you want no limit
  # 
  # Can be overrode via the permission `pet.saves.<amount>`
  # Bypass permission: `pet.saves.bypass`
  # 
  # Default: -1
  default-limit: -1
  # This option allows you to list pet types and the limit for how many saves they can have
  # 
  # Example: "COW-2"
  # This example will make it so the COW pet type can only be saved 2 times
  # 
  # Can be overrode via the permission `pet.saves.<type>.<amount>`
  # Bypass permission: `pet.saves.bypass`
  # Bypass permission: `pet.saves.<type>.bypass`
  # 
  # Default: []
  pet-type-limits:
  - ''
```