### PR TITLE
Fix pet vanishing when clicked with bucket

### DIFF
--- a/NMS_Master/src/main/java/simplepets/brainsynder/nms/entity/EntityFishPet.java
+++ b/NMS_Master/src/main/java/simplepets/brainsynder/nms/entity/EntityFishPet.java
@@ -1,15 +1,23 @@
 package simplepets.brainsynder.nms.entity;
 
+import net.minecraft.nbt.CompoundTag;
 import net.minecraft.network.syncher.EntityDataAccessor;
 import net.minecraft.network.syncher.EntityDataSerializers;
 import net.minecraft.network.syncher.SynchedEntityData;
+import net.minecraft.sounds.SoundEvent;
+import net.minecraft.sounds.SoundEvents;
 import net.minecraft.world.entity.EntityType;
 import net.minecraft.world.entity.Mob;
+import net.minecraft.world.entity.animal.Bucketable;
+import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.item.Items;
 import simplepets.brainsynder.api.entity.misc.IEntityFishPet;
 import simplepets.brainsynder.api.pet.PetType;
 import simplepets.brainsynder.api.user.PetUser;
 
-public class EntityFishPet extends EntityPet implements IEntityFishPet {
+// Implement Bucketable so the server resends the entity when the client tries
+// to pick it up with a bucket
+public class EntityFishPet extends EntityPet implements IEntityFishPet, Bucketable {
     private static final EntityDataAccessor<Boolean> FROM_BUCKET;
 
     public EntityFishPet(EntityType<? extends Mob> entitytypes, PetType type, PetUser user) {
@@ -20,6 +28,34 @@ public class EntityFishPet extends EntityPet implements IEntityFishPet {
     protected void registerDatawatchers() {
         super.registerDatawatchers();
         this.entityData.define(FROM_BUCKET, false);
+    }
+
+    @Override
+    public boolean fromBucket() {
+        return entityData.get(FROM_BUCKET);
+    }
+
+    @Override
+    public void setFromBucket(boolean b) {
+        entityData.set(FROM_BUCKET, b);
+    }
+
+    @Override
+    public void saveToBucketTag(ItemStack itemStack) {
+    }
+
+    @Override
+    public void loadFromBucketTag(CompoundTag compoundTag) {
+    }
+
+    @Override
+    public ItemStack getBucketItemStack() {
+        return new ItemStack(Items.WATER_BUCKET);
+    }
+
+    @Override
+    public SoundEvent getPickupSound() {
+        return SoundEvents.BUCKET_FILL_FISH;
     }
 
     static {

--- a/NMS_Master/src/main/java/simplepets/brainsynder/nms/entity/list/EntityAxolotlPet.java
+++ b/NMS_Master/src/main/java/simplepets/brainsynder/nms/entity/list/EntityAxolotlPet.java
@@ -1,10 +1,16 @@
 package simplepets.brainsynder.nms.entity.list;
 
 import lib.brainsynder.nbt.StorageTagCompound;
+import net.minecraft.nbt.CompoundTag;
 import net.minecraft.network.syncher.EntityDataAccessor;
 import net.minecraft.network.syncher.EntityDataSerializers;
 import net.minecraft.network.syncher.SynchedEntityData;
+import net.minecraft.sounds.SoundEvent;
+import net.minecraft.sounds.SoundEvents;
 import net.minecraft.world.entity.EntityType;
+import net.minecraft.world.entity.animal.Bucketable;
+import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.item.Items;
 import simplepets.brainsynder.api.entity.passive.IEntityAxolotlPet;
 import simplepets.brainsynder.api.pet.PetType;
 import simplepets.brainsynder.api.user.PetUser;
@@ -14,7 +20,9 @@ import simplepets.brainsynder.nms.entity.EntityAgeablePet;
 /**
  * NMS: {@link net.minecraft.server.v1_16_R3.EntityAxolotl}
  */
-public class EntityAxolotlPet extends EntityAgeablePet implements IEntityAxolotlPet {
+// Implement Bucketable so the server resends the entity when the client tries
+// to pick it up with a bucket
+public class EntityAxolotlPet extends EntityAgeablePet implements IEntityAxolotlPet, Bucketable {
     private static final EntityDataAccessor<Integer> DATA_VARIANT;
     private static final EntityDataAccessor<Boolean> DATA_PLAYING_DEAD;
     private static final EntityDataAccessor<Boolean> FROM_BUCKET;
@@ -64,6 +72,34 @@ public class EntityAxolotlPet extends EntityAgeablePet implements IEntityAxolotl
     @Override
     public void setVariant(AxolotlVariant variant) {
         entityData.set(DATA_VARIANT, variant.ordinal());
+    }
+
+    @Override
+    public boolean fromBucket() {
+        return entityData.get(FROM_BUCKET);
+    }
+
+    @Override
+    public void setFromBucket(boolean b) {
+        entityData.set(FROM_BUCKET, b);
+    }
+
+    @Override
+    public void saveToBucketTag(ItemStack itemStack) {
+    }
+
+    @Override
+    public void loadFromBucketTag(CompoundTag compoundTag) {
+    }
+
+    @Override
+    public ItemStack getBucketItemStack() {
+        return new ItemStack(Items.WATER_BUCKET);
+    }
+
+    @Override
+    public SoundEvent getPickupSound() {
+        return SoundEvents.BUCKET_FILL_FISH;
     }
 
     static {


### PR DESCRIPTION
If a player clicks a Axolotl/Cod/Pufferfish/Salmon/Tadpole/TropicalFish pet with a water bucket, it vanishes for them. The server still thinks the pet exists and all other clients can still see the pet, but the clicker can not.

I have the impression that the client removes the pet itself instead of waiting for the server to do it. Spigot contains a fix for non-pet entities here: https://hub.spigotmc.org/stash/projects/SPIGOT/repos/craftbukkit/browse/nms-patches/net/minecraft/server/network/PlayerConnection.patch#1234. It doesn't apply to pets, because pets don't implement Bucketable.

This pull requests makes the affected pets implement Bucketable to fix the issue. I filled in the required methods with some reasonable code. I think their implementations could also be empty. I only tested this PR on 1.19.3.