### PR TITLE
Fix pet rename triggering twice through menu

### DIFF
--- a/MAIN/src/main/java/simplepets/brainsynder/menu/items/list/Name.java
+++ b/MAIN/src/main/java/simplepets/brainsynder/menu/items/list/Name.java
@@ -43,6 +43,7 @@ public class Name extends Item {
                     masterUser.getPlayer().performCommand("pet rename " + pet.getPetType().getName());
                 }
             }.runTaskLater(PetCore.getInstance(), 2);
+            return;
         }
 
         PetSelectorMenu menu = InventoryManager.SELECTOR;


### PR DESCRIPTION
The `name` menu item would open the pet selection menu even if a pet was already selected, erroneously resulting in the rename command being run twice, and capturing the player's chat input twice. This was due to a missing early return in the item's onClick handler. Adding that return, in line with how it's done in the other menu items, fixes this!