### PR TITLE
fix: regression with killable pets due to method signature changes

### DIFF
--- a/nms/master/src/simplepets/brainsynder/nms/entity/EntityPet.java
+++ b/nms/master/src/simplepets/brainsynder/nms/entity/EntityPet.java
@@ -19,6 +19,7 @@ import org.bukkit.ChatColor;
 import org.bukkit.Location;
 import org.bukkit.entity.Entity;
 import org.bukkit.entity.Player;
+import org.bukkit.event.entity.EntityDamageEvent;
 import simplepets.brainsynder.api.entity.IEntityPet;
 import simplepets.brainsynder.api.entity.misc.IEntityControllerPet;
 import simplepets.brainsynder.api.event.entity.EntityNameChangeEvent;
@@ -161,6 +162,12 @@ public abstract class EntityPet extends EntityBase implements IEntityPet {
     // God damnit Spigot changing the method name...
     // See: https://tiny.bsdevelopment.org/spigot-changed-damage-method
     protected boolean actuallyHurt(DamageSource damagesource, float f) {
+        return false;
+    }
+
+    // Method signature changed again
+    // https://hub.spigotmc.org/stash/projects/SPIGOT/repos/craftbukkit/commits/764a541c5b5fd872ec3cacfc3d51d88e8599d569#nms-patches%2Fnet%2Fminecraft%2Fworld%2Fentity%2FEntityLiving.patch?t=872
+    protected boolean actuallyHurt(DamageSource damageSource, float f, EntityDamageEvent event) {
         return false;
     }
 

--- a/nms/master/src/simplepets/brainsynder/nms/entity/list/EntityArmorStandPet.java
+++ b/nms/master/src/simplepets/brainsynder/nms/entity/list/EntityArmorStandPet.java
@@ -26,6 +26,7 @@ import org.bukkit.configuration.file.YamlConfiguration;
 import org.bukkit.entity.Entity;
 import org.bukkit.entity.Player;
 import org.bukkit.event.entity.CreatureSpawnEvent;
+import org.bukkit.event.entity.EntityDamageEvent;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.meta.SkullMeta;
 import org.bukkit.util.EulerAngle;
@@ -664,6 +665,12 @@ public class EntityArmorStandPet extends ArmorStand implements IEntityArmorStand
     // God damnit Spigot changing the method name...
     // See: https://tiny.bsdevelopment.org/spigot-changed-damage-method
     protected boolean actuallyHurt(DamageSource damagesource, float f) {
+        return false;
+    }
+
+    // Method signature changed again
+    // https://hub.spigotmc.org/stash/projects/SPIGOT/repos/craftbukkit/commits/764a541c5b5fd872ec3cacfc3d51d88e8599d569#nms-patches%2Fnet%2Fminecraft%2Fworld%2Fentity%2FEntityLiving.patch?t=872
+    protected boolean actuallyHurt(DamageSource damageSource, float f, EntityDamageEvent event) {
         return false;
     }
 

--- a/nms/master/src/simplepets/brainsynder/nms/entity/list/EntityShulkerPet.java
+++ b/nms/master/src/simplepets/brainsynder/nms/entity/list/EntityShulkerPet.java
@@ -15,6 +15,7 @@ import org.bukkit.Location;
 import org.bukkit.entity.Entity;
 import org.bukkit.entity.Player;
 import org.bukkit.event.entity.CreatureSpawnEvent;
+import org.bukkit.event.entity.EntityDamageEvent;
 import simplepets.brainsynder.api.entity.hostile.IEntityShulkerPet;
 import simplepets.brainsynder.api.entity.misc.IEntityControllerPet;
 import simplepets.brainsynder.api.other.ParticleHandler;
@@ -372,6 +373,12 @@ public class EntityShulkerPet extends Shulker implements IEntityShulkerPet {
     // God damnit Spigot changing the method name...
     // See: https://tiny.bsdevelopment.org/spigot-changed-damage-method
     protected boolean actuallyHurt(DamageSource damagesource, float f) {
+        return false;
+    }
+
+    // Method signature changed again
+    // https://hub.spigotmc.org/stash/projects/SPIGOT/repos/craftbukkit/commits/764a541c5b5fd872ec3cacfc3d51d88e8599d569#nms-patches%2Fnet%2Fminecraft%2Fworld%2Fentity%2FEntityLiving.patch?t=872
+    protected boolean actuallyHurt(DamageSource damageSource, float f, EntityDamageEvent event) {
         return false;
     }
 

--- a/nms/master/src/simplepets/brainsynder/nms/entity/special/EntityGhostStand.java
+++ b/nms/master/src/simplepets/brainsynder/nms/entity/special/EntityGhostStand.java
@@ -17,6 +17,7 @@ import net.minecraft.world.level.Level;
 import net.minecraft.world.phys.Vec3;
 import org.bukkit.Location;
 import org.bukkit.event.entity.CreatureSpawnEvent;
+import org.bukkit.event.entity.EntityDamageEvent;
 import simplepets.brainsynder.nms.VersionTranslator;
 
 public class EntityGhostStand extends ArmorStand {
@@ -79,7 +80,11 @@ public class EntityGhostStand extends ArmorStand {
         return false;
     }
 
-
+    // Method signature changed again
+    // https://hub.spigotmc.org/stash/projects/SPIGOT/repos/craftbukkit/commits/764a541c5b5fd872ec3cacfc3d51d88e8599d569#nms-patches%2Fnet%2Fminecraft%2Fworld%2Fentity%2FEntityLiving.patch?t=872
+    protected boolean actuallyHurt(DamageSource damageSource, float f, EntityDamageEvent event) {
+        return false;
+    }
 
 
     /**


### PR DESCRIPTION
Upstream (Spigot) recently changed the method signature of LivingEntity#actuallyHurt(), so pets became damageable and killable again. This fixes the bug, tested with Paper version 1.21-48-master@70b0e84 (2024-07-08T19:27:11Z) (Implementing API version 1.21-R0.1-SNAPSHOT) and seems to work fine.