### PR TITLE
Fix default wolf variant = STANDING

### DIFF
--- a/plugin-api/src/simplepets/brainsynder/api/pet/data/WolfTypeData.java
+++ b/plugin-api/src/simplepets/brainsynder/api/pet/data/WolfTypeData.java
@@ -20,7 +20,7 @@ public class WolfTypeData extends PetData<IEntityWolfPet> {
 
     @Override
     public Object getDefaultValue() {
-        return ArmadilloPhase.STANDING;
+        return WolfType.PALE;
     }
 
     @Override


### PR DESCRIPTION
`data.type.default = STANDING` in the default `wolf.json` pet config, meaning players cannot equip the wolf pet without changing this in the config