### PR TITLE
Fix DataMenu#update() NPE, fix ListCommand send empty message

### DIFF
--- a/plugin-core/src/simplepets/brainsynder/commands/list/ListCommand.java
+++ b/plugin-core/src/simplepets/brainsynder/commands/list/ListCommand.java
@@ -28,7 +28,9 @@ public class ListCommand extends PetSubCommand {
     @Override
     public void run(CommandSender sender) {
         Tellraw raw = Tellraw.getInstance("Pet List: ").color("#d1c9c9");
+        boolean removeLastPart = false;
         for (PetType type : PetType.values()) {
+            removeLastPart = true;
             if (type == PetType.UNKNOWN) continue;
             Optional<IPetConfig> config = SimplePets.getPetConfigManager().getPetConfig(type);
             String tooltip = "";
@@ -57,7 +59,8 @@ public class ListCommand extends PetSubCommand {
 
             raw.then(", ").color("#d1c9c9");
         }
-        raw.removeLastPart();
+        if(removeLastPart)
+            raw.removeLastPart();
         raw.send(sender);
     }
 }

--- a/plugin-core/src/simplepets/brainsynder/menu/inventory/DataMenu.java
+++ b/plugin-core/src/simplepets/brainsynder/menu/inventory/DataMenu.java
@@ -119,6 +119,7 @@ public class DataMenu extends CustomInventory {
         if (!isEnabled()) return;
         if (user == null) return;
         Player player = user.getPlayer();
+        if(player == null)  return;
         if (!user.hasPets()) {
             player.closeInventory();
             return;


### PR DESCRIPTION
DataMenu#update(): Fix NPE 
ListCommand: If a player has no pet permissions, they should only see "List:" instead of an "empty message" (which cannot be sent and will result in exception)